### PR TITLE
New story-specific params/metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,6 @@ The following fields (all optional) can be supplied in a `themeSelector` metadat
 * **`themes`**  –  An array of themes, overriding the `themes` passed to `addDecorator(withThemesProvider(themes))` (if any).
 * **`singleThemeMessage`**  –  A `string`, containing a message to be displayed in the "Themes" Panel when there's only one theme available.
 * **`showSingleThemeButton`**  –  A `boolean` (default `true`), specifying whether to display the single theme button when there's only one theme available.
-* **`buttonAttributes`**  –  An array of `string`s, specifying [HTML element attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes)
-  to add to the theme buttons in the "Themes" Panel (each attribute's value will be the theme's name).  This is useful for targeting the buttons
-  using [CSS attribute selectors](https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors) to programmatically click them, eg:
-  `document.querySelector('[data-theme-name="dark"]').click()`.
 
 For example:
 
@@ -79,8 +75,7 @@ const customThemes = [theme3, theme4];
 storiesOf("demo", module)
   .add("demo div", () => <div>DEMO</div>, {
     themeSelector: {
-      themes:           customThemes,
-      buttonAttributes: ["data-theme-name"]
+      themes: customThemes
     }
   });
 ```

--- a/README.md
+++ b/README.md
@@ -4,17 +4,20 @@
 
 ![](https://media.giphy.com/media/FfFvOA9C0h9bhfCuNX/giphy.gif)
 
-#### Notice
+## Notice
 Only support storybook 4 and newer
 
 
-#### Installation
+## Setup
+
+### 1. Install
 ```bash
 yarn add storybook-addon-styled-component-theme --dev
 ```
 
+### 2. Register
 
-#### Add to .storybook/addons.js 
+Add to `.storybook/addons.js`:
 
 ```javascript
 import 'storybook-addon-styled-component-theme/dist/src/register'; // v1.1.0^
@@ -22,7 +25,10 @@ import 'storybook-addon-styled-component-theme/dist/src/register'; // v1.1.0^
 import 'storybook-addon-styled-component-theme/dist/register'; // v1.0.7
 ```
 
-#### addDecorator to .storybook/config.js
+### 3. Configure themes
+
+Configure `themes` in `.storybook/config.js` for all stories:
+
 ```javascript
 import {addDecorator} from '@storybook/react';
 import {withThemesProvider} from 'storybook-addon-styled-component-theme';
@@ -31,11 +37,10 @@ const themes = [theme1, theme2];
 addDecorator(withThemesProvider(themes));
 ```
 
-> or
+or configure `themes` for a single group of stories:
 
-#### addDecorator to stories 
-
-```javascript
+```jsx
+import {addDecorator} from '@storybook/react';
 import {withThemesProvider} from 'storybook-addon-styled-component-theme';
 
 const themes = [theme1, theme2];
@@ -45,11 +50,60 @@ storiesOf("demo", module)
   .add("demo div", () => <div>DEMO</div>);
 ```
 
-#### Remind
+Once `addDecorator()` has been called, it's possible to customise the `themes` for a single story (see the documentation below on metadata for more details):
+
+```jsx
+const customThemes = [theme3, theme4];
+
+storiesOf("demo", module)
+  .add("demo div", () => <div>DEMO</div>, { themeSelector: { themes: customThemes } });
+```
+
+### 4. Configure story-specific metadata
+
+The following fields (all optional) can be supplied in a `themeSelector` metadata object for a story:
+
+* **`themes`**  –  An array of themes, overriding the `themes` passed to `addDecorator(withThemesProvider(themes))` (if any).
+* **`singleThemeMessage`**  –  A `string`, containing a message to be displayed in the "Themes" Panel when there's only one theme available.
+* **`showSingleThemeButton`**  –  A `boolean` (default `true`), specifying whether to display the single theme button when there's only one theme available.
+* **`buttonAttributes`**  –  An array of `string`s, specifying [HTML element attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes)
+  to add to the theme buttons in the "Themes" Panel (each attribute's value will be the theme's name).  This is useful for targeting the buttons
+  using [CSS attribute selectors](https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors) to programmatically click them, eg:
+  `document.querySelector('[data-theme-name="dark"]').click()`.
+
+For example:
+
+```jsx
+const customThemes = [theme3, theme4];
+
+storiesOf("demo", module)
+  .add("demo div", () => <div>DEMO</div>, {
+    themeSelector: {
+      themes:           customThemes,
+      buttonAttributes: ["data-theme-name"]
+    }
+  });
+```
+
+```jsx
+const customThemes = [theme5];
+
+storiesOf("demo", module)
+  .add("demo div", () => <div>DEMO</div>, {
+    themeSelector: {
+      themes:                customThemes,
+      singleThemeMessage:    "There is only one theme configured for this story.",
+      showSingleThemeButton: false
+    }
+  });
+```
+
+
+## Remind
 Make sure every theme object has a `name` property
 
 
-#### Contributing
+## Contributing
 
 `yarn`
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ storiesOf("demo", module)
 ```
 
 
-## Remind
+## Reminder
 Make sure every theme object has a `name` property
 
 

--- a/src/Themes.tsx
+++ b/src/Themes.tsx
@@ -12,7 +12,7 @@ export interface ThemeProps {
 interface ThemeState {
     stateTheme: Theme;
     setStateTheme: (theme: Theme) => void;
-    themes: List<Theme>;
+    stateThemes: List<Theme>;
     setThemes: (themes: List<Theme>) => void;
 }
 
@@ -23,9 +23,9 @@ interface ThemeHandler {
 
 type BaseComponentProps = ThemeProps & ThemeState & ThemeHandler;
 
-const BaseComponent: React.SFC<BaseComponentProps> = ({onSelectTheme, themes, stateTheme}) => (
+const BaseComponent: React.SFC<BaseComponentProps> = ({onSelectTheme, stateThemes, stateTheme}) => (
     <div style={RowStyle}>
-        {themes.map((th, i) => {
+        {stateThemes.map((th, i) => {
             const buttonStyle = th === stateTheme ? SelectedButtonStyle : ButtonStyle;
             return <div style={buttonStyle} key={i} onClick={() => onSelectTheme(th)}>{th.name}</div>;
         }).toArray()}
@@ -34,7 +34,7 @@ const BaseComponent: React.SFC<BaseComponentProps> = ({onSelectTheme, themes, st
 
 export const Themes = compose<BaseComponentProps, ThemeProps>(
     withState("stateTheme", "setStateTheme", null),
-    withState("themes", "setThemes", List()),
+    withState("stateThemes", "setThemes", List()),
     withHandlers<ThemeProps & ThemeState, ThemeHandler>({
         onSelectTheme: ({channel, setStateTheme, api}) => (theme) => {
             setStateTheme(theme);

--- a/src/Themes.tsx
+++ b/src/Themes.tsx
@@ -98,6 +98,7 @@ export const Themes = compose<BaseComponentProps, ThemeProps>(
             if (themes.count() > 0) {
                 const theme = themes.find((t) => t.name === themeName) || themes.first();
                 setStateTheme(theme);
+                api.setQueryParams({theme: theme.name});
                 channel.emit("panelThemeSelected", theme);
             }
         },

--- a/src/Themes.tsx
+++ b/src/Themes.tsx
@@ -14,10 +14,12 @@ export interface ThemeProps {
 export interface ThemeMetadataParams {
     themes?: Theme[];
     singleThemeMessage?: string;
+    showSingleThemeButton?: boolean;
 }
 
 interface ThemeExtraProps {
     singleThemeMessage?: string;
+    showSingleThemeButton: boolean;
 }
 
 interface ThemeState {
@@ -36,32 +38,40 @@ interface ThemeHandler {
 type BaseComponentProps = ThemeProps & ThemeExtraProps & ThemeState & ThemeHandler;
 
 const BaseComponent: React.SFC<BaseComponentProps> =
-    ({onSelectTheme, stateThemes, stateTheme, singleThemeMessage}) => (
+    ({onSelectTheme, stateThemes, stateTheme, singleThemeMessage, showSingleThemeButton}) => (
         <div>
             {stateThemes.size === 1 && singleThemeMessage && (
                 <div style={MessageStyle}>{singleThemeMessage}</div>
             )}
-            <div style={RowStyle}>
-                {stateThemes.map((th: Theme) => {
-                    const style: React.CSSProperties = ((th === stateTheme) ? SelectedButtonStyle : ButtonStyle);
-                    return (
-                        <div style={style} key={th.name} onClick={() => onSelectTheme(th)}>
-                            {th.name}
-                        </div>
-                    );
-                }).toArray()}
-            </div>
+            {(stateThemes.size > 1 || showSingleThemeButton) && (
+                <div style={RowStyle}>
+                    {stateThemes.map((th: Theme) => {
+                        const style: React.CSSProperties = ((th === stateTheme) ? SelectedButtonStyle : ButtonStyle);
+                        return (
+                            <div style={style} key={th.name} onClick={() => onSelectTheme(th)}>
+                                {th.name}
+                            </div>
+                        );
+                    }).toArray()}
+                </div>
+            )}
         </div>
     );
 
 export const Themes = compose<BaseComponentProps, ThemeProps>(
     mapProps<ThemeProps, ThemeProps & ThemeExtraProps>((props) => {
-        const mappedProps: ThemeProps & ThemeExtraProps = {...props};
+        const mappedProps: ThemeProps & ThemeExtraProps = {
+            ...props,
+            showSingleThemeButton: true,
+        };
         const currentStoryData = props.api.getCurrentStoryData();
         if (currentStoryData) {
             const params: ThemeMetadataParams | undefined = props.api.getParameters(currentStoryData.id, metadataKey);
             if (params) {
                 mappedProps.singleThemeMessage = params.singleThemeMessage;
+                if (typeof params.showSingleThemeButton === "boolean") {
+                    mappedProps.showSingleThemeButton = params.showSingleThemeButton;
+                }
             }
         }
         return mappedProps;

--- a/src/Themes.tsx
+++ b/src/Themes.tsx
@@ -15,13 +15,11 @@ export interface ThemeMetadataParams {
     themes?: Theme[];
     singleThemeMessage?: string;
     showSingleThemeButton?: boolean;
-    buttonAttributes?: string[];
 }
 
 interface ThemeExtraProps {
     singleThemeMessage?: string;
     showSingleThemeButton: boolean;
-    buttonAttributes: string[];
 }
 
 interface ThemeState {
@@ -40,7 +38,7 @@ interface ThemeHandler {
 type BaseComponentProps = ThemeProps & ThemeExtraProps & ThemeState & ThemeHandler;
 
 const BaseComponent: React.SFC<BaseComponentProps> =
-    ({onSelectTheme, stateThemes, stateTheme, singleThemeMessage, showSingleThemeButton, buttonAttributes}) => (
+    ({onSelectTheme, stateThemes, stateTheme, singleThemeMessage, showSingleThemeButton}) => (
         <div>
             {stateThemes.size === 1 && singleThemeMessage && (
                 <div style={MessageStyle}>{singleThemeMessage}</div>
@@ -49,11 +47,8 @@ const BaseComponent: React.SFC<BaseComponentProps> =
                 <div style={RowStyle}>
                     {stateThemes.map((theme: Theme) => {
                         const style: React.CSSProperties = ((theme === stateTheme) ? SelectedButtonStyle : ButtonStyle);
-                        const themeNameProps: object = buttonAttributes.reduce(
-                            (obj: object, attr: string) => ({ ...obj, [attr]: theme.name}), {},
-                        );
                         return (
-                            <div style={style} key={theme.name} onClick={() => onSelectTheme(theme)} {...themeNameProps}>
+                            <div style={style} key={theme.name} onClick={() => onSelectTheme(theme)}>
                                 {theme.name}
                             </div>
                         );
@@ -68,14 +63,12 @@ export const Themes = compose<BaseComponentProps, ThemeProps>(
         const mappedProps: ThemeProps & ThemeExtraProps = {
             ...props,
             showSingleThemeButton: true,
-            buttonAttributes: [],
         };
         const currentStoryData = props.api.getCurrentStoryData();
         if (currentStoryData) {
             const params: ThemeMetadataParams | undefined = props.api.getParameters(currentStoryData.id, metadataKey);
             if (params) {
                 mappedProps.singleThemeMessage = params.singleThemeMessage;
-                mappedProps.buttonAttributes   = params.buttonAttributes || [];
                 if (typeof params.showSingleThemeButton === "boolean") {
                     mappedProps.showSingleThemeButton = params.showSingleThemeButton;
                 }

--- a/src/Themes.tsx
+++ b/src/Themes.tsx
@@ -10,7 +10,7 @@ export interface ThemeProps {
 }
 
 interface ThemeState {
-    theme: Theme;
+    stateTheme: Theme;
     setTheme: (theme: Theme) => void;
     themes: List<Theme>;
     setThemes: (themes: List<Theme>) => void;
@@ -23,17 +23,17 @@ interface ThemeHandler {
 
 type BaseComponentProps = ThemeProps & ThemeState & ThemeHandler;
 
-const BaseComponent: React.SFC<BaseComponentProps> = ({onSelectTheme, themes, theme}) => (
+const BaseComponent: React.SFC<BaseComponentProps> = ({onSelectTheme, themes, stateTheme}) => (
     <div style={RowStyle}>
         {themes.map((th, i) => {
-            const buttonStyle = th === theme ? SelectedButtonStyle : ButtonStyle;
+            const buttonStyle = th === stateTheme ? SelectedButtonStyle : ButtonStyle;
             return <div style={buttonStyle} key={i} onClick={() => onSelectTheme(th)}>{th.name}</div>;
         }).toArray()}
     </div>
 );
 
 export const Themes = compose<BaseComponentProps, ThemeProps>(
-    withState("theme", "setTheme", null),
+    withState("stateTheme", "setTheme", null),
     withState("themes", "setThemes", List()),
     withHandlers<ThemeProps & ThemeState, ThemeHandler>({
         onSelectTheme: ({channel, setTheme, api}) => (theme) => {
@@ -63,7 +63,7 @@ export const Themes = compose<BaseComponentProps, ThemeProps>(
         },
     }),
     branch<BaseComponentProps>(
-        ({theme, active}) => !theme || !active,
+        ({stateTheme, active}) => !stateTheme || !active,
         renderNothing,
     ),
 )(BaseComponent);

--- a/src/Themes.tsx
+++ b/src/Themes.tsx
@@ -1,7 +1,9 @@
 import {List} from "immutable";
 import * as React from "react";
+import {STORY_RENDERED} from "@storybook/core-events";
 import {branch, compose, lifecycle, renderNothing, withHandlers, withState} from "recompose";
 import {Theme} from "./types/Theme";
+import {metadataKey} from "./constants";
 
 export interface ThemeProps {
     channel: any;
@@ -19,6 +21,7 @@ interface ThemeState {
 interface ThemeHandler {
     onSelectTheme: (theme: Theme) => void;
     onReceiveThemes: (theme: Theme[]) => void;
+    onStoryRender: (storyId: string) => void;
 }
 
 type BaseComponentProps = ThemeProps & ThemeState & ThemeHandler;
@@ -51,15 +54,24 @@ export const Themes = compose<BaseComponentProps, ThemeProps>(
                 channel.emit("panelThemeSelected", theme);
             }
         },
+        onStoryRender: ({api, channel}) => (storyId: string) => {
+            const params = api.getParameters(storyId, metadataKey);
+            if (params && params.themes) {
+                channel.emit("storyThemesReceived", params.themes);
+            }
+        },
     }),
     lifecycle<BaseComponentProps, BaseComponentProps>({
         componentDidMount() {
-            const {channel, onReceiveThemes} = this.props;
+            const {api, channel, onReceiveThemes, onStoryRender} = this.props;
             channel.on("decoratorThemesReceived", onReceiveThemes);
+            channel.on("storyThemesReceived", onReceiveThemes);
+            api.on(STORY_RENDERED, onStoryRender);
         },
         componentWillUnmount() {
             const {channel, onReceiveThemes} = this.props;
             channel.removeListener("decoratorThemesReceived", onReceiveThemes);
+            channel.removeListener("storyThemesReceived", onReceiveThemes);
         },
     }),
     branch<BaseComponentProps>(

--- a/src/Themes.tsx
+++ b/src/Themes.tsx
@@ -80,6 +80,24 @@ export const Themes = compose<BaseComponentProps, ThemeProps>(
     ),
 )(BaseComponent);
 
+const fontFamily: string = [
+    "-apple-system",
+    "\".SFNSText-Regular\"",
+    "\"San Francisco\"",
+    "BlinkMacSystemFont",
+    "\"Segoe UI\"",
+    "\"Roboto\"",
+    "\"Oxygen\"",
+    "\"Ubuntu\"",
+    "\"Cantarell\"",
+    "\"Fira Sans\"",
+    "\"Droid Sans\"",
+    "\"Helvetica Neue\"",
+    "\"Lucida Grande\"",
+    "\"Arial\"",
+    "sans-serif",
+].join(", ");
+
 const RowStyle: React.CSSProperties = {
     padding: "10px",
     display: "flex",
@@ -95,8 +113,7 @@ const ButtonStyle: React.CSSProperties = {
     padding: "13px",
     marginRight: "15px",
     cursor: "pointer",
-    // tslint:disable-next-line:max-line-length
-    fontFamily: "-apple-system, \".SFNSText-Regular\", \"San Francisco\", BlinkMacSystemFont, \"Segoe UI\", \"Roboto\", \"Oxygen\", \"Ubuntu\", \"Cantarell\", \"Fira Sans\", \"Droid Sans\", \"Helvetica Neue\", \"Lucida Grande\", \"Arial\", sans-serif",
+    fontFamily,
     lineHeight: "25px",
 };
 

--- a/src/Themes.tsx
+++ b/src/Themes.tsx
@@ -15,11 +15,13 @@ export interface ThemeMetadataParams {
     themes?: Theme[];
     singleThemeMessage?: string;
     showSingleThemeButton?: boolean;
+    buttonAttributes?: string[];
 }
 
 interface ThemeExtraProps {
     singleThemeMessage?: string;
     showSingleThemeButton: boolean;
+    buttonAttributes: string[];
 }
 
 interface ThemeState {
@@ -38,7 +40,7 @@ interface ThemeHandler {
 type BaseComponentProps = ThemeProps & ThemeExtraProps & ThemeState & ThemeHandler;
 
 const BaseComponent: React.SFC<BaseComponentProps> =
-    ({onSelectTheme, stateThemes, stateTheme, singleThemeMessage, showSingleThemeButton}) => (
+    ({onSelectTheme, stateThemes, stateTheme, singleThemeMessage, showSingleThemeButton, buttonAttributes}) => (
         <div>
             {stateThemes.size === 1 && singleThemeMessage && (
                 <div style={MessageStyle}>{singleThemeMessage}</div>
@@ -47,8 +49,11 @@ const BaseComponent: React.SFC<BaseComponentProps> =
                 <div style={RowStyle}>
                     {stateThemes.map((th: Theme) => {
                         const style: React.CSSProperties = ((th === stateTheme) ? SelectedButtonStyle : ButtonStyle);
+                        const themeNameProps: object = buttonAttributes.reduce(
+                            (obj: object, attr: string) => ({ ...obj, [attr]: th.name}), {},
+                        );
                         return (
-                            <div style={style} key={th.name} onClick={() => onSelectTheme(th)}>
+                            <div style={style} key={th.name} onClick={() => onSelectTheme(th)} {...themeNameProps}>
                                 {th.name}
                             </div>
                         );
@@ -63,12 +68,14 @@ export const Themes = compose<BaseComponentProps, ThemeProps>(
         const mappedProps: ThemeProps & ThemeExtraProps = {
             ...props,
             showSingleThemeButton: true,
+            buttonAttributes: [],
         };
         const currentStoryData = props.api.getCurrentStoryData();
         if (currentStoryData) {
             const params: ThemeMetadataParams | undefined = props.api.getParameters(currentStoryData.id, metadataKey);
             if (params) {
                 mappedProps.singleThemeMessage = params.singleThemeMessage;
+                mappedProps.buttonAttributes   = params.buttonAttributes || [];
                 if (typeof params.showSingleThemeButton === "boolean") {
                     mappedProps.showSingleThemeButton = params.showSingleThemeButton;
                 }

--- a/src/Themes.tsx
+++ b/src/Themes.tsx
@@ -13,7 +13,7 @@ interface ThemeState {
     stateTheme: Theme;
     setStateTheme: (theme: Theme) => void;
     stateThemes: List<Theme>;
-    setThemes: (themes: List<Theme>) => void;
+    setStateThemes: (themes: List<Theme>) => void;
 }
 
 interface ThemeHandler {
@@ -34,17 +34,17 @@ const BaseComponent: React.SFC<BaseComponentProps> = ({onSelectTheme, stateTheme
 
 export const Themes = compose<BaseComponentProps, ThemeProps>(
     withState("stateTheme", "setStateTheme", null),
-    withState("stateThemes", "setThemes", List()),
+    withState("stateThemes", "setStateThemes", List()),
     withHandlers<ThemeProps & ThemeState, ThemeHandler>({
         onSelectTheme: ({channel, setStateTheme, api}) => (theme) => {
             setStateTheme(theme);
             api.setQueryParams({theme: theme.name});
             channel.emit("panelThemeSelected", theme.name);
         },
-        onReceiveThemes: ({setStateTheme, setThemes, channel, api}) => (newThemes: Theme[]) => {
+        onReceiveThemes: ({setStateTheme, setStateThemes, channel, api}) => (newThemes: Theme[]) => {
             const themes = List(newThemes);
             const themeName = api.getQueryParam("theme");
-            setThemes(List(themes));
+            setStateThemes(List(themes));
             if (themes.count() > 0) {
                 const theme = themes.find((t) => t.name === themeName) || themes.first();
                 setStateTheme(theme);

--- a/src/Themes.tsx
+++ b/src/Themes.tsx
@@ -47,14 +47,14 @@ const BaseComponent: React.SFC<BaseComponentProps> =
             )}
             {(stateThemes.size > 1 || showSingleThemeButton) && (
                 <div style={RowStyle}>
-                    {stateThemes.map((th: Theme) => {
-                        const style: React.CSSProperties = ((th === stateTheme) ? SelectedButtonStyle : ButtonStyle);
+                    {stateThemes.map((theme: Theme) => {
+                        const style: React.CSSProperties = ((theme === stateTheme) ? SelectedButtonStyle : ButtonStyle);
                         const themeNameProps: object = buttonAttributes.reduce(
-                            (obj: object, attr: string) => ({ ...obj, [attr]: th.name}), {},
+                            (obj: object, attr: string) => ({ ...obj, [attr]: theme.name}), {},
                         );
                         return (
-                            <div style={style} key={th.name} onClick={() => onSelectTheme(th)} {...themeNameProps}>
-                                {th.name}
+                            <div style={style} key={theme.name} onClick={() => onSelectTheme(theme)} {...themeNameProps}>
+                                {theme.name}
                             </div>
                         );
                     }).toArray()}

--- a/src/Themes.tsx
+++ b/src/Themes.tsx
@@ -39,7 +39,7 @@ export const Themes = compose<BaseComponentProps, ThemeProps>(
         onSelectTheme: ({channel, setTheme, api}) => (theme) => {
             setTheme(theme);
             api.setQueryParams({theme: theme.name});
-            channel.emit("selectTheme", theme.name);
+            channel.emit("panelThemeSelected", theme.name);
         },
         onReceiveThemes: ({setTheme, setThemes, channel, api}) => (newThemes: Theme[]) => {
             const themes = List(newThemes);
@@ -48,7 +48,7 @@ export const Themes = compose<BaseComponentProps, ThemeProps>(
             if (themes.count() > 0) {
                 const theme = themes.find((t) => t.name === themeName) || themes.first();
                 setTheme(theme);
-                channel.emit("selectTheme", theme.name);
+                channel.emit("panelThemeSelected", theme.name);
             }
         },
     }),

--- a/src/Themes.tsx
+++ b/src/Themes.tsx
@@ -39,7 +39,7 @@ export const Themes = compose<BaseComponentProps, ThemeProps>(
         onSelectTheme: ({channel, setStateTheme, api}) => (theme) => {
             setStateTheme(theme);
             api.setQueryParams({theme: theme.name});
-            channel.emit("panelThemeSelected", theme.name);
+            channel.emit("panelThemeSelected", theme);
         },
         onReceiveThemes: ({setStateTheme, setStateThemes, channel, api}) => (newThemes: Theme[]) => {
             const themes = List(newThemes);
@@ -48,7 +48,7 @@ export const Themes = compose<BaseComponentProps, ThemeProps>(
             if (themes.count() > 0) {
                 const theme = themes.find((t) => t.name === themeName) || themes.first();
                 setStateTheme(theme);
-                channel.emit("panelThemeSelected", theme.name);
+                channel.emit("panelThemeSelected", theme);
             }
         },
     }),

--- a/src/Themes.tsx
+++ b/src/Themes.tsx
@@ -55,11 +55,11 @@ export const Themes = compose<BaseComponentProps, ThemeProps>(
     lifecycle<BaseComponentProps, BaseComponentProps>({
         componentDidMount() {
             const {channel, onReceiveThemes} = this.props;
-            channel.on("setThemes", onReceiveThemes);
+            channel.on("decoratorThemesReceived", onReceiveThemes);
         },
         componentWillUnmount() {
             const {channel, onReceiveThemes} = this.props;
-            channel.removeListener("setThemes", onReceiveThemes);
+            channel.removeListener("decoratorThemesReceived", onReceiveThemes);
         },
     }),
     branch<BaseComponentProps>(

--- a/src/Themes.tsx
+++ b/src/Themes.tsx
@@ -28,9 +28,13 @@ type BaseComponentProps = ThemeProps & ThemeState & ThemeHandler;
 
 const BaseComponent: React.SFC<BaseComponentProps> = ({onSelectTheme, stateThemes, stateTheme}) => (
     <div style={RowStyle}>
-        {stateThemes.map((th, i) => {
-            const buttonStyle = th === stateTheme ? SelectedButtonStyle : ButtonStyle;
-            return <div style={buttonStyle} key={i} onClick={() => onSelectTheme(th)}>{th.name}</div>;
+        {stateThemes.map((th: Theme) => {
+            const style: React.CSSProperties = ((th === stateTheme) ? SelectedButtonStyle : ButtonStyle);
+            return (
+                <div style={style} key={th.name} onClick={() => onSelectTheme(th)}>
+                    {th.name}
+                </div>
+            );
         }).toArray()}
     </div>
 );

--- a/src/Themes.tsx
+++ b/src/Themes.tsx
@@ -11,7 +11,7 @@ export interface ThemeProps {
 
 interface ThemeState {
     stateTheme: Theme;
-    setTheme: (theme: Theme) => void;
+    setStateTheme: (theme: Theme) => void;
     themes: List<Theme>;
     setThemes: (themes: List<Theme>) => void;
 }
@@ -33,21 +33,21 @@ const BaseComponent: React.SFC<BaseComponentProps> = ({onSelectTheme, themes, st
 );
 
 export const Themes = compose<BaseComponentProps, ThemeProps>(
-    withState("stateTheme", "setTheme", null),
+    withState("stateTheme", "setStateTheme", null),
     withState("themes", "setThemes", List()),
     withHandlers<ThemeProps & ThemeState, ThemeHandler>({
-        onSelectTheme: ({channel, setTheme, api}) => (theme) => {
-            setTheme(theme);
+        onSelectTheme: ({channel, setStateTheme, api}) => (theme) => {
+            setStateTheme(theme);
             api.setQueryParams({theme: theme.name});
             channel.emit("panelThemeSelected", theme.name);
         },
-        onReceiveThemes: ({setTheme, setThemes, channel, api}) => (newThemes: Theme[]) => {
+        onReceiveThemes: ({setStateTheme, setThemes, channel, api}) => (newThemes: Theme[]) => {
             const themes = List(newThemes);
             const themeName = api.getQueryParam("theme");
             setThemes(List(themes));
             if (themes.count() > 0) {
                 const theme = themes.find((t) => t.name === themeName) || themes.first();
-                setTheme(theme);
+                setStateTheme(theme);
                 channel.emit("panelThemeSelected", theme.name);
             }
         },

--- a/src/ThemesProvider.tsx
+++ b/src/ThemesProvider.tsx
@@ -20,7 +20,7 @@ interface ThemesProviderState {
 }
 
 interface ThemesProviderHandler {
-    onSelectTheme: (name: string) => void;
+    onSelectTheme: (theme: Theme) => void;
 }
 
 type BaseComponentProps = ThemesProviderProps & ThemesProviderMapProps & ThemesProviderState & ThemesProviderHandler;
@@ -37,8 +37,7 @@ export const ThemesProvider = compose<BaseComponentProps, ThemesProviderProps>(
     }),
     withState("stateTheme", "setStateTheme", null),
     withHandlers<ThemesProviderProps & ThemesProviderMapProps & ThemesProviderState, ThemesProviderHandler>({
-        onSelectTheme: ({setStateTheme, decoratorThemes}) => (name) => {
-            const theme = decoratorThemes.find((th: Theme) => th.name === name);
+        onSelectTheme: ({setStateTheme}) => (theme) => {
             setStateTheme(theme);
         },
     }),

--- a/src/ThemesProvider.tsx
+++ b/src/ThemesProvider.tsx
@@ -46,13 +46,13 @@ export const ThemesProvider = compose<BaseComponentProps, ThemesProviderProps>(
         componentDidMount() {
             const {onSelectTheme, decoratorThemes} = this.props;
             const channel = addons.getChannel();
-            channel.on("selectTheme", onSelectTheme);
+            channel.on("panelThemeSelected", onSelectTheme);
             channel.emit("decoratorThemesReceived", decoratorThemes);
         },
         componentWillUnmount() {
             const {onSelectTheme} = this.props;
             const channel = addons.getChannel();
-            channel.removeListener("selectTheme", onSelectTheme);
+            channel.removeListener("panelThemeSelected", onSelectTheme);
         },
     }),
     branch<BaseComponentProps>(

--- a/src/ThemesProvider.tsx
+++ b/src/ThemesProvider.tsx
@@ -6,7 +6,7 @@ import {ThemeProvider, ThemeProviderComponent} from "styled-components";
 import {Theme} from "./types/Theme";
 
 export interface ThemesProviderProps {
-    themes: List<Theme>;
+    decoratorThemes: List<Theme>;
     CustomThemeProvider?: ThemeProviderComponent<any>;
 }
 
@@ -37,17 +37,17 @@ export const ThemesProvider = compose<BaseComponentProps, ThemesProviderProps>(
     }),
     withState("theme", "setTheme", null),
     withHandlers<ThemesProviderProps & ThemesProviderMapProps & ThemesProviderState, ThemesProviderHandler>({
-        onSelectTheme: ({setTheme, themes}) => (name) => {
-            const theme = themes.find((th: Theme) => th.name === name);
+        onSelectTheme: ({setTheme, decoratorThemes}) => (name) => {
+            const theme = decoratorThemes.find((th: Theme) => th.name === name);
             setTheme(theme);
         },
     }),
     lifecycle<BaseComponentProps, BaseComponentProps>({
         componentDidMount() {
-            const {onSelectTheme, themes} = this.props;
+            const {onSelectTheme, decoratorThemes} = this.props;
             const channel = addons.getChannel();
             channel.on("selectTheme", onSelectTheme);
-            channel.emit("setThemes", themes);
+            channel.emit("setThemes", decoratorThemes);
         },
         componentWillUnmount() {
             const {onSelectTheme} = this.props;

--- a/src/ThemesProvider.tsx
+++ b/src/ThemesProvider.tsx
@@ -15,7 +15,7 @@ interface ThemesProviderMapProps {
 }
 
 interface ThemesProviderState {
-    theme: Theme;
+    stateTheme: Theme;
     setTheme: (theme: Theme) => void;
 }
 
@@ -25,8 +25,8 @@ interface ThemesProviderHandler {
 
 type BaseComponentProps = ThemesProviderProps & ThemesProviderMapProps & ThemesProviderState & ThemesProviderHandler;
 
-const BaseComponent: React.SFC<BaseComponentProps> = ({theme, Provider, children}) => (
-  <Provider theme={theme} children={children as any}/>
+const BaseComponent: React.SFC<BaseComponentProps> = ({stateTheme, Provider, children}) => (
+  <Provider theme={stateTheme} children={children as any}/>
 );
 
 export const ThemesProvider = compose<BaseComponentProps, ThemesProviderProps>(
@@ -35,7 +35,7 @@ export const ThemesProvider = compose<BaseComponentProps, ThemesProviderProps>(
         const Provider = CustomThemeProvider ? CustomThemeProvider : ThemeProvider;
         return {...props, Provider};
     }),
-    withState("theme", "setTheme", null),
+    withState("stateTheme", "setTheme", null),
     withHandlers<ThemesProviderProps & ThemesProviderMapProps & ThemesProviderState, ThemesProviderHandler>({
         onSelectTheme: ({setTheme, decoratorThemes}) => (name) => {
             const theme = decoratorThemes.find((th: Theme) => th.name === name);
@@ -56,7 +56,7 @@ export const ThemesProvider = compose<BaseComponentProps, ThemesProviderProps>(
         },
     }),
     branch<BaseComponentProps>(
-        (props) => !props.theme,
+        (props) => !props.stateTheme,
         renderNothing,
     ),
 )(BaseComponent);

--- a/src/ThemesProvider.tsx
+++ b/src/ThemesProvider.tsx
@@ -47,7 +47,7 @@ export const ThemesProvider = compose<BaseComponentProps, ThemesProviderProps>(
             const {onSelectTheme, decoratorThemes} = this.props;
             const channel = addons.getChannel();
             channel.on("selectTheme", onSelectTheme);
-            channel.emit("setThemes", decoratorThemes);
+            channel.emit("decoratorThemesReceived", decoratorThemes);
         },
         componentWillUnmount() {
             const {onSelectTheme} = this.props;

--- a/src/ThemesProvider.tsx
+++ b/src/ThemesProvider.tsx
@@ -16,7 +16,7 @@ interface ThemesProviderMapProps {
 
 interface ThemesProviderState {
     stateTheme: Theme;
-    setTheme: (theme: Theme) => void;
+    setStateTheme: (theme: Theme) => void;
 }
 
 interface ThemesProviderHandler {
@@ -35,11 +35,11 @@ export const ThemesProvider = compose<BaseComponentProps, ThemesProviderProps>(
         const Provider = CustomThemeProvider ? CustomThemeProvider : ThemeProvider;
         return {...props, Provider};
     }),
-    withState("stateTheme", "setTheme", null),
+    withState("stateTheme", "setStateTheme", null),
     withHandlers<ThemesProviderProps & ThemesProviderMapProps & ThemesProviderState, ThemesProviderHandler>({
-        onSelectTheme: ({setTheme, decoratorThemes}) => (name) => {
+        onSelectTheme: ({setStateTheme, decoratorThemes}) => (name) => {
             const theme = decoratorThemes.find((th: Theme) => th.name === name);
-            setTheme(theme);
+            setStateTheme(theme);
         },
     }),
     lifecycle<BaseComponentProps, BaseComponentProps>({

--- a/src/__tests__/Themes.spec.tsx
+++ b/src/__tests__/Themes.spec.tsx
@@ -5,18 +5,22 @@ import {Themes} from "../Themes";
 
 describe("Themes spec", () => {
     it("should render proper", () => {
+        const api = {
+            on: stub(),
+            getCurrentStoryData: stub(),
+        };
         const channel = {
             on: stub(),
             emit: stub(),
             removeListener: stub(),
         };
 
-        const component = mount(<Themes api={null} channel={channel} active={true} />);
+        const component = mount(<Themes api={api} channel={channel} active={true} />);
         expect(component.render()).toMatchSnapshot();
-        expect(channel.on.calledOnce).toBeTruthy();
+        expect(channel.on.calledTwice).toBeTruthy();
         expect(channel.emit.notCalled).toBeTruthy();
 
         component.unmount();
-        expect(channel.removeListener.calledOnce).toBeTruthy();
+        expect(channel.removeListener.calledTwice).toBeTruthy();
     });
 });

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -1,0 +1,2 @@
+/** The object key for passing metadata to this addon for a story. */
+export const metadataKey: string = "themeSelector";

--- a/src/withThemesProvider.tsx
+++ b/src/withThemesProvider.tsx
@@ -5,5 +5,5 @@ import {ThemesProvider} from "./ThemesProvider";
 import {Theme} from "./types/Theme";
 
 export const withThemesProvider = (themes: Theme[], CustomThemeProvider?: ThemeProviderComponent<any>) => (story): JSX.Element => {
-    return <ThemesProvider themes={List(themes)} CustomThemeProvider={CustomThemeProvider}>{story()}</ThemesProvider>;
+    return <ThemesProvider decoratorThemes={List(themes)} CustomThemeProvider={CustomThemeProvider}>{story()}</ThemesProvider>;
 };

--- a/src/withThemesProvider.tsx
+++ b/src/withThemesProvider.tsx
@@ -4,6 +4,6 @@ import {ThemeProviderComponent} from "styled-components";
 import {ThemesProvider} from "./ThemesProvider";
 import {Theme} from "./types/Theme";
 
-export const withThemesProvider = (themes: Theme[], CustomThemeProvider?: ThemeProviderComponent<any>) => (story): JSX.Element => {
+export const withThemesProvider = (themes: Theme[] = [], CustomThemeProvider?: ThemeProviderComponent<any>) => (story): JSX.Element => {
     return <ThemesProvider decoratorThemes={List(themes)} CustomThemeProvider={CustomThemeProvider}>{story()}</ThemesProvider>;
 };


### PR DESCRIPTION
This PR consists of three categories:


## 1. Renamed internal items

The purpose of this renaming is to improve the codebase's [greppability](http://john.freml.in/grep-orientated-programming):

> Greppability is the ease with which one can navigate a body of source code just by searching simple text keywords. From determining what code caused an output to tracing all the callers of a function, there's plenty that can be possible by text searching - or not depending how names are used or the project structured. And the easier it is, the faster and more reliably new developers can be productive.

For example, the name `setThemes` is currently used for two different things in `src/Themes.tsx`:

1. The function which updates the `themes` state variable.
2. The channel event which is received when the `src/ThemesProvider.tsx` component mounts.

By giving these items unique (and more specific) names, the codebase's greppability is improved.

**Note: Only internal items have been renamed. No items exposed in the addon's public API have been renamed, so this is not a breaking change.**

Commits:

* cdbcd20  –  Rename `themes` prop to `decoratorThemes`
* cf6225f  –  Rename `theme` to `stateTheme`
* 0e56d61  –  Rename `setTheme` to `setStateTheme`
* eb5bcc1  –  Rename `setThemes` to `decoratorThemesReceived`
* 7c49044  –  Rename `selectTheme` to `panelThemeSelected`
* e48f1f5  –  Rename `theme` to `stateTheme`
* fc3746e  –  Rename `setTheme` to `setStateTheme`
* bacde06  –  Rename `themes` to `stateThemes`
* cf2c742  –  Rename `setThemes` to `setStateThemes`

Complete diff – https://github.com/Sage/storybook-addon-styled-component-theme/compare/5678bfb...cf2c742


## 2. Miscellaneous improvements

* 3998235  –  Refactor `fontFamily` to avoid TSLint issue
* 421ffef  –  Improve React keys for theme buttons


## 3. Implemented new story-specific params/metadata

**Note: These new params are all optional, so this is not a breaking change.**

The new params are documented in the updated `README.md`:

> The following fields (all optional) can be supplied in a `themeSelector` metadata object for a story:
>
> * **`themes`**  –  An array of themes, overriding the `themes` passed to `addDecorator(withThemesProvider(themes))` (if any).
> * **`singleThemeMessage`**  –  A `string`, containing a message to be displayed in the "Themes" Panel when there's only one theme available.
> * **`showSingleThemeButton`**  –  A `boolean` (default `true`), specifying whether to display the single theme button when there's only one theme available.
>
> For example:
>
> ```jsx
> const customThemes = [theme3, theme4];
>
> storiesOf("demo", module)
>   .add("demo div", () => <div>DEMO</div>, {
>     themeSelector: {
>       themes: customThemes
>     }
>   });
> ```
>
> ```jsx
> const customThemes = [theme5];
>
> storiesOf("demo", module)
>   .add("demo div", () => <div>DEMO</div>, {
>     themeSelector: {
>       themes:                customThemes,
>       singleThemeMessage:    "There is only one theme configured for this story.",
>       showSingleThemeButton: false
>     }
>   });
> ```

Commits:

* 8d83996  –  `panelThemeSelected`: pass theme instead of name
* 23efc4b  –  Create `src/constants.tsx`
* f84dafa  –  Implement `storyThemesReceived` functionality
* fe9b282  –  `withThemesProvider`: default value for `themes`
* b7de211  –  Implement `singleThemeMessage` functionality
* a7794ed  –  Implement `showSingleThemeButton` functionality
* 20d3b93  –  Update `Themes.spec.tsx`
* 890d82b  –  Update `README.md`
* a3dc4c7  –  `onReceiveThemes()`: need to call `setQueryParams()`
* e4a1df9  –  Minor cleanup in `README.md` and `src/Themes.tsx`
